### PR TITLE
Add a user_variable option to the pay method

### DIFF
--- a/lib/generators/templates/sofort.rb
+++ b/lib/generators/templates/sofort.rb
@@ -14,4 +14,6 @@ Sofort.setup do |config|
   config.currency_code = "EUR"
   config.reason = "Reason"
 
+  config.user_variable = 'user_variable'
+
 end

--- a/lib/sofort/client.rb
+++ b/lib/sofort/client.rb
@@ -55,6 +55,7 @@ module Sofort
       email_customer = opts[:email_customer] ||  Sofort.email_customer
       notification_email = opts[:notification_email] ||  Sofort.notification_email
       notification_url = opts[:notification_url] ||  Sofort.notification_url
+      user_variable = opts[:user_variable] ||  Sofort.user_variable
 
       {
         amount: amount,
@@ -67,6 +68,9 @@ module Sofort
           country_code: country_code
         },
         email_customer: email_customer,
+        user_variables: {
+          user_variable: user_variable
+        },
         notification_emails: {
           notification_email: notification_email
         },


### PR DESCRIPTION
This allows to pass a custom value to the `pay` method:

```
client.pay(12, 'skopu', { user_variable: "foo bar" })
```

and get it back with the `details` method:

```
details = client.details(token)
puts details['user_variables']['user_variable']
# => "foo bar"
```
