### PR TITLE
Allow client to set the language code

### DIFF
--- a/lib/generators/templates/sofort.rb
+++ b/lib/generators/templates/sofort.rb
@@ -1,19 +1,18 @@
 Sofort.setup do |config|
 
-  config.base_url = "https://api.sofort.com/api/xml"
+  config.base_url = 'https://api.sofort.com/api/xml'
   config.user_id = 'sofort_user_id'
   config.api_key = 'api_key'
   config.abort_url = 'abort_url'
   config.success_url = 'success_url'
   config.notification_url = 'notification_url'
-
+  config.language_code = 'de'
   config.email_customer = 'email_customer'
   config.notification_email = 'notification_email'
   config.project_id = 'project_id'
-  config.country_code = "DE"
-  config.currency_code = "EUR"
-  config.reason = "Reason"
-
+  config.country_code = 'DE'
+  config.currency_code = 'EUR'
+  config.reason = 'Reason'
   config.user_variable = 'user_variable'
 
 end

--- a/lib/sofort/client.rb
+++ b/lib/sofort/client.rb
@@ -53,6 +53,7 @@ module Sofort
       success_url = opts[:success_url] ||  Sofort.success_url
       abort_url = opts[:abort_url] ||  Sofort.abort_url
       email_customer = opts[:email_customer] ||  Sofort.email_customer
+      language_code = opts[:language_code] || Sofort.language_code
       notification_email = opts[:notification_email] ||  Sofort.notification_email
       notification_url = opts[:notification_url] ||  Sofort.notification_url
       user_variable = opts[:user_variable] ||  Sofort.user_variable
@@ -60,6 +61,7 @@ module Sofort
       {
         amount: amount,
         currency_code: currency_code,
+        language_code: language_code,
         reasons: {
           reason: reason
         },


### PR DESCRIPTION
Hey @skopu,

We are using your Sofort gem on a multilingual site. It would be nice to have the Sofort interface in the same language as the one the user choose on our site to keep the UX consistent. This pull request adds the possibility to set the preferred language in the client.

Thank you!
