### PR TITLE
[fix] Removed missing config params

### DIFF
--- a/lib/generators/templates/sofort.rb
+++ b/lib/generators/templates/sofort.rb
@@ -6,14 +6,12 @@ Sofort.setup do |config|
   config.abort_url = 'abort_url'
   config.success_url = 'success_url'
   config.notification_url = 'notification_url'
-  config.language_code = 'de'
   config.email_customer = 'email_customer'
   config.notification_email = 'notification_email'
   config.project_id = 'project_id'
   config.country_code = 'DE'
   config.currency_code = 'EUR'
   config.reason = 'Reason'
-  config.user_variable = 'user_variable'
   config.project_id = 'project_id'
 
 end


### PR DESCRIPTION
There were two calls in the initial configuration generator template that are no longer used in `Sofort.setup`. This PR should fix the initial setting step using the gem.
