### PR TITLE
[fix] Added missing accessors

### DIFF
--- a/lib/sofort.rb
+++ b/lib/sofort.rb
@@ -15,7 +15,9 @@ module Sofort
   mattr_accessor :country_code
   mattr_accessor :currency_code
   mattr_accessor :reason
-
+  mattr_accessor :language_code
+  mattr_accessor :user_variable
+  
   @@user_id = 'sofort_user_id'
   @@api_key = 'api_key'
 

--- a/sofort-rails.gemspec
+++ b/sofort-rails.gemspec
@@ -2,7 +2,7 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'sofort/version'
-require "active_support/all"
+
 Gem::Specification.new do |spec|
   spec.name          = "sofort"
   spec.version       = Sofort::VERSION


### PR DESCRIPTION
Add support to two other params that can be used when you set up a SOFORT payment: `language_code` and `user_variable`, so you can pass them with the hash in `Sofort::Client#pay`